### PR TITLE
PRMT-4201

### DIFF
--- a/src/main/java/uk/nhs/prm/repo/ehrtransferservice/exceptions/EhrDeleteRequestException.java
+++ b/src/main/java/uk/nhs/prm/repo/ehrtransferservice/exceptions/EhrDeleteRequestException.java
@@ -1,0 +1,9 @@
+package uk.nhs.prm.repo.ehrtransferservice.exceptions;
+
+public class EhrDeleteRequestException extends RuntimeException {
+    private static final String BASE_MESSAGE = "Unexpected response from EHR Deletion request, details: %s.";
+
+    public EhrDeleteRequestException(String message) {
+        super(String.format(BASE_MESSAGE, message));
+    }
+}

--- a/src/main/java/uk/nhs/prm/repo/ehrtransferservice/services/Broker.java
+++ b/src/main/java/uk/nhs/prm/repo/ehrtransferservice/services/Broker.java
@@ -5,12 +5,18 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import uk.nhs.prm.repo.ehrtransferservice.database.TransferStore;
 import uk.nhs.prm.repo.ehrtransferservice.gp2gp_message_models.ParsedMessage;
-import uk.nhs.prm.repo.ehrtransferservice.message_publishers.*;
+import uk.nhs.prm.repo.ehrtransferservice.message_publishers.FragmentMessagePublisher;
+import uk.nhs.prm.repo.ehrtransferservice.message_publishers.LargeEhrMessagePublisher;
+import uk.nhs.prm.repo.ehrtransferservice.message_publishers.NegativeAcknowledgementMessagePublisher;
+import uk.nhs.prm.repo.ehrtransferservice.message_publishers.ParsingDlqPublisher;
+import uk.nhs.prm.repo.ehrtransferservice.message_publishers.PositiveAcknowledgementMessagePublisher;
+import uk.nhs.prm.repo.ehrtransferservice.message_publishers.SmallEhrMessagePublisher;
 import uk.nhs.prm.repo.ehrtransferservice.models.ack.Acknowledgement;
+import uk.nhs.prm.repo.ehrtransferservice.services.ehr_repo.EhrRepoService;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class Broker {
     private static final String LARGE_MESSAGE_FRAGMENT_INTERACTION_ID = "COPC_IN000001UK01";
     private static final String EHR_EXTRACT_INTERACTION_ID = "RCMR_IN030000UK06";
@@ -22,7 +28,7 @@ public class Broker {
     private final NegativeAcknowledgementMessagePublisher negativeAcknowledgementMessagePublisher;
     private final PositiveAcknowledgementMessagePublisher positiveAcknowledgementMessagePublisher;
     private final ParsingDlqPublisher parsingDlqPublisher;
-    private final EhrInUnhandledMessagePublisher ehrInUnhandledMessagePublisher;
+    private final EhrRepoService ehrRepoService;
 
     private final TransferStore transferStore;
 
@@ -65,11 +71,15 @@ public class Broker {
         boolean conversationIdPresent = transferStore.isConversationIdPresent(parsedMessage.getConversationId().toString());
 
         if (conversationIdPresent) {
-            log.info("Found conversation id in db - received EHR IN message");
+            log.info("Found Conversation ID '{}' in Transfer Tracker Database - received EHR IN message", parsedMessage.getConversationId());
             sendMessageToCorrespondingTopicPublisher(parsedMessage);
         } else {
-            log.info("Did not find conversation id in db - sending to EHR IN Unhandled topic");
-            ehrInUnhandledMessagePublisher.sendMessage(parsedMessage.getMessageBody(), parsedMessage.getConversationId());
+            log.info(
+                    "Did not find Conversation ID '{}' in Transfer Tracker Database - Sending DELETE request to EHR Repository based on NHS Number",
+                    parsedMessage.getConversationId()
+            );
+
+            ehrRepoService.softDeleteEhrRecord(parsedMessage.getNhsNumber());
         }
     }
 }

--- a/src/main/java/uk/nhs/prm/repo/ehrtransferservice/services/ehr_repo/EhrRepoService.java
+++ b/src/main/java/uk/nhs/prm/repo/ehrtransferservice/services/ehr_repo/EhrRepoService.java
@@ -24,4 +24,7 @@ public class EhrRepoService {
         return new StoreMessageResult(confirmedMessageStored);
     }
 
+    public void softDeleteEhrRecord(String nhsNumber) {
+        this.ehrRepoClient.softDeleteEhrRecord(nhsNumber);
+    }
 }


### PR DESCRIPTION
1. Temporarily remove the ability to send EHR Requests to ORC-Out (as it will not be deployed for FoT).
2. Added logic to send a DELETE HTTP request to the `/patients/{nhs_number}` on the EHR Repository API, in turn marking it as soft deleted and allowing the Deletion Lambda to pick it up.