### PR TITLE
PRMT-4322

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation 'junit:junit:4.13.2'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
     implementation 'org.apache.qpid:proton-j:0.33.10'
+    implementation 'ch.qos.logback:logback-core:1.4.14'
 
     implementation platform('software.amazon.awssdk:bom:2.20.130')
     implementation 'software.amazon.awssdk:cloudwatch'


### PR DESCRIPTION
- Override `ch.qos.logback:logback-core` to use 1.4.14 to address Dependabot Alerts #46, #44.