### PR TITLE
PRMT-4322

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,8 @@ dependencies {
     implementation 'junit:junit:4.13.2'
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api:3.0.1'
     implementation 'org.apache.qpid:proton-j:0.33.10'
+    implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
+    implementation 'org.apache.commons:commons-compress:1.25.0'
 
     implementation platform('software.amazon.awssdk:bom:2.20.130')
     implementation 'software.amazon.awssdk:cloudwatch'
@@ -84,7 +86,9 @@ dependencies {
     testImplementation(platform('org.junit:junit-bom:5.7.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')
     spotbugsPlugins 'com.h3xstream.findsecbugs:findsecbugs-plugin:1.11.0'
+    testImplementation 'commons-fileupload:commons-fileupload:1.5'
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.1"
+    testImplementation 'com.google.guava:guava:33.0.0-jre'
     testImplementation 'org.awaitility:awaitility:4.2.0'
 
     integrationImplementation 'com.swiftmq:swiftmq-client:12.5.4'


### PR DESCRIPTION
Added the following dependencies to override vulnerabilities:

- implementation 'org.bouncycastle:bcprov-jdk18on:1.77'
- implementation 'org.apache.commons:commons-compress:1.25.0'
- testImplementation 'commons-fileupload:commons-fileupload:1.5'
- testImplementation 'com.google.guava:guava:33.0.0-jre'