### PR TITLE
PRMT-4277

### DIFF
--- a/terraform/pre-prod.tfvars
+++ b/terraform/pre-prod.tfvars
@@ -3,6 +3,6 @@ environment = "pre-prod"
 task_cpu    = 512
 task_memory = 1024
 
-service_desired_count = "1"
+service_desired_count = "0"
 
 log_level = "info"

--- a/terraform/prod.tfvars
+++ b/terraform/prod.tfvars
@@ -3,6 +3,6 @@ environment = "prod"
 task_cpu    = 512
 task_memory = 1024
 
-service_desired_count = "1"
+service_desired_count = "0"
 
 log_level = "info"


### PR DESCRIPTION
- Set the ECS desired count to 0 for the prod and pre-prod environment so that the CloudWatch Alarm can be the trigger.