### PR TITLE
PRMT-4482

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -688,11 +688,6 @@ data "aws_iam_policy_document" "sns_topic_policies" {
 
     resources = [local.sns_topic_arns[count.index]]
 
-    principals {
-      type        = "AWS"
-      identifiers = ["*"]
-    }
-
     condition {
       test     = "StringEquals"
       variable = "AWS:SourceOwner"


### PR DESCRIPTION
While the `deploy` step was running on the pipeline it yielded the following error:

```terraform
│ Error: error creating IAM policy dev-ehr-transfer-service-small-ehr-sns-topic-sns-policy: MalformedPolicyDocument: Policy document should not specify a principal.
│ 	status code: 400, request id: 7728a5ee-d5da-409e-a253-bbbea8c70759
│ 
│   with aws_iam_policy.sns_topic_policies[4],
│   on iam.tf line 666, in resource "aws_iam_policy" "sns_topic_policies":
│  666: resource "aws_iam_policy" "sns_topic_policies" {
```

To resolve this - I removed the principal from the SNS topic policies.