### PR TITLE
PRMT-4482

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -664,7 +664,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_metrics_policy_attach" {
 }
 
 module "sns_enforce_https" {
-  source        = "modules/sns_enforce_https"
+  source        = "./modules/sns_enforce_https"
   for_each      = toset(local.sns_topic_arns)
   sns_topic_arn = each.value
 }


### PR DESCRIPTION
Pipeline fix attempt - following error appears on GoCD.

```terraform
│ Error: Invalid module source address
│ 
│ Module "sns_enforce_https" (declared at iam.tf line 666) has invalid source
│ address "modules/sns_enforce_https": Terraform cannot detect a supported
│ external module source type for modules/sns_enforce_https.
```